### PR TITLE
global: entrypoint_name parameter renaming

### DIFF
--- a/invenio_celery/ext.py
+++ b/invenio_celery/ext.py
@@ -43,15 +43,15 @@ class InvenioCelery(object):
             self.init_app(app, **kwargs)
 
     def init_app(self, app, assets=None,
-                 entrypoint_name='invenio_celery.tasks', **kwargs):
+                 entry_point_group='invenio_celery.tasks', **kwargs):
         """Initialize application object."""
         self.init_config(app.config)
         self.celery = FlaskCeleryExt(app).celery
 
-        if entrypoint_name:
+        if entry_point_group:
             task_packages = []
             for item in pkg_resources.iter_entry_points(
-                    group=entrypoint_name):
+                    group=entry_point_group):
                 task_packages.append(item.module_name)
 
             if task_packages:

--- a/tests/test_invenio_celery.py
+++ b/tests/test_invenio_celery.py
@@ -81,7 +81,7 @@ def test_enabled_autodiscovery(app):
 @patch("pkg_resources.iter_entry_points", _mock_entry_points)
 def test_only_first_tasks(app):
     """Test loading different entrypoint group."""
-    ext = InvenioCelery(app, entrypoint_name='only_first_tasks')
+    ext = InvenioCelery(app, entry_point_group='only_first_tasks')
     assert 'conftest.shared_compute' in ext.celery.tasks.keys()
     assert 'first_tasks.first_task' in ext.celery.tasks.keys()
     assert 'second_tasks.second_task_a' not in ext.celery.tasks.keys()
@@ -90,7 +90,7 @@ def test_only_first_tasks(app):
 
 def test_disabled_autodiscovery(app):
     """Test disabled discovery."""
-    ext = InvenioCelery(app, entrypoint_name=None)
+    ext = InvenioCelery(app, entry_point_group=None)
     assert 'conftest.shared_compute' in ext.celery.tasks.keys()
     assert 'first_tasks.first_task' not in ext.celery.tasks.keys()
     assert 'second_tasks.second_task_a' not in ext.celery.tasks.keys()


### PR DESCRIPTION
* Renames entrypoint_name parameter to entry_point_group to follow
  conventions in other modules.

Signed-off-by: Sami Hiltunen <sami.mikael.hiltunen@cern.ch>