### PR TITLE
installation: pytest-runner>=2.7.1

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env sh
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -22,6 +22,8 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
+[aliases]
+test = pytest
 
 [build_sphinx]
 source-dir = docs/

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ tests_require = [
     'pytest-cache>=1.0',
     'pytest-cov>=1.8.0',
     'pytest-pep8>=1.0.6',
+    'pytest-runner>=2.7.1',
     'pytest>=2.8.0',
 ]
 
@@ -65,41 +66,6 @@ install_requires = [
 ]
 
 packages = find_packages()
-
-
-class PyTest(TestCommand):
-    """PyTest Test."""
-
-    user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]
-
-    def initialize_options(self):
-        """Init pytest."""
-        TestCommand.initialize_options(self)
-        self.pytest_args = []
-        try:
-            from ConfigParser import ConfigParser
-        except ImportError:
-            from configparser import ConfigParser
-        config = ConfigParser()
-        config.read('pytest.ini')
-        self.pytest_args = config.get('pytest', 'addopts').split(' ')
-
-    def finalize_options(self):
-        """Finalize pytest."""
-        TestCommand.finalize_options(self)
-        if hasattr(self, '_test_args'):
-            self.test_suite = ''
-        else:
-            self.test_args = []
-            self.test_suite = True
-
-    def run_tests(self):
-        """Run tests."""
-        # import here, cause outside the eggs aren't loaded
-        import pytest
-        errno = pytest.main(self.pytest_args)
-        sys.exit(errno)
-
 
 # Get the version string. Cannot be done with import!
 g = {}
@@ -149,5 +115,4 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Development Status :: 3 - Alpha',
     ],
-    cmdclass={'test': PyTest},
 )


### PR DESCRIPTION
* Replaces the manual pytest integration with pytest-runner.

Signed-off-by: Sami Hiltunen <sami.mikael.hiltunen@cern.ch>