### PR TITLE
docs: celery beat schedule

### DIFF
--- a/docs/_ext/ultramock.py
+++ b/docs/_ext/ultramock.py
@@ -29,10 +29,12 @@ import types
 try:
     import unittest.mock as mock
 except ImportError:
-    import mock
+    from mock import mock
 
 # skip `_is_magic` check.
 orig_is_magic = mock._is_magic
+
+
 def always_false(*args, **kwargs):
     return False
 
@@ -40,6 +42,8 @@ def always_false(*args, **kwargs):
 # avoid spec configuration for mocked classes with super classes.
 # honestly this does not happen very often and is kind of a tricky case.
 orig_mock_add_spec = mock.NonCallableMock._mock_add_spec
+
+
 def mock_add_spec_fake(self, spec, spec_set):
     orig_mock_add_spec(self, None, None)
 
@@ -77,15 +81,19 @@ class MockedModule(types.ModuleType):
 
 # overwrite imports
 orig_import = __import__
+
+
 def import_mock(name, *args, **kwargs):
     try:
         return orig_import(name, *args, **kwargs)
     except ImportError:
         return MockedModule(name)
-import_patch = mock.patch('__builtin__.__import__', side_effect=import_mock)
 
 
 # public methods
+import_patch = mock.patch('__builtin__.__import__', side_effect=import_mock)
+
+
 def activate():
     mock._is_magic = always_false
     mock.NonCallableMock._mock_add_spec = mock_add_spec_fake

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -76,7 +76,9 @@ author = u'CERN'
 
 # Get the version string. Cannot be done with import!
 g = {}
-with open(os.path.join('..', 'invenio_celery', 'version.py'), 'rt') as fp:
+with open(os.path.join(os.path.dirname(__file__), '..',
+                       'invenio_celery', 'version.py'),
+          'rt') as fp:
     exec(fp.read(), g)
     version = g['__version__']
 

--- a/invenio_celery/__init__.py
+++ b/invenio_celery/__init__.py
@@ -69,6 +69,26 @@ is as simple as:
     from mymoudle.tasks import sum
     result = sum.delay(2, 2)
 
+Periodic tasks
+--------------
+Periodic tasks can be configured via ``CELERYBEAT_SCHEDULE`` configuration
+variable:
+
+.. code-block:: python
+
+    # config.py
+    CELERYBEAT_SCHEDULE = {
+        'indexer': {
+            'task': 'invenio_indexer.tasks.process_bulk_queue',
+            'schedule': timedelta(minutes=5),
+        },
+    }
+
+For further information about see `Periodic Tasks
+<http://docs.celeryproject.org/en/latest/userguide/periodic-tasks.html>`_
+chapter of the `Celery documentation
+<http://docs.celeryproject.org/en/latest/index.html>`_.
+
 
 Celery workers
 --------------

--- a/pytest.ini
+++ b/pytest.ini
@@ -23,4 +23,5 @@
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
 [pytest]
-addopts = --pep8 --ignore=docs --cov=invenio_celery --cov-report=term-missing
+pep8ignore = docs/conf.py ALL
+addopts = --pep8 --doctest-glob="*.rst" --doctest-modules --cov=invenio_celery --cov-report=term-missing docs tests invenio_celery

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -28,5 +28,4 @@ pydocstyle invenio_celery tests && \
 isort -rc -c -df && \
 check-manifest --ignore ".travis-*" && \
 sphinx-build -qnNW docs docs/_build/html && \
-python setup.py test && \
-sphinx-build -qnNW -b doctest docs docs/_build/doctest
+python setup.py test

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup_requires = [
 ]
 
 install_requires = [
-    'Flask-CeleryExt>=0.2.0',
+    'Flask-CeleryExt>=0.3.0',
     'Flask>=0.11',
     'redis>=2.10.0',
     'msgpack-python>=0.4.6',


### PR DESCRIPTION
* Add periodic task documentation. (closes #43)

* doctests are now executed with pytest instead of sphinx. (closes #14)