### PR TITLE
global: upgrade msgpack dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ install_requires = [
     'Flask-CeleryExt>=0.3.0',
     'Flask>=0.11',
     'redis>=2.10.0',
-    'msgpack-python>=0.4.6',
+    'msgpack>=0.5.2',
 ]
 
 packages = find_packages()


### PR DESCRIPTION
* uses msgpack instead of msgpack-python since it has been renamed
* closes #58