### PR TITLE
dependencies: use centrally manange dependencies and remove pytest-celery

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,14 +16,7 @@ readme = open('README.rst').read()
 history = open('CHANGES.rst').read()
 
 tests_require = [
-    'mock>=1.3.0',
-    'pytest-invenio>=1.3.4',
-    # TODO: Remove all lines below with pytest-invenio v1.4.0:
-    "pytest-cov>=2.10.1",
-    "pytest-isort>=1.2.0",
-    "pytest-pycodestyle>=2.2.0",
-    "pytest-pydocstyle>=2.2.0",
-    "pytest>=6,<7",
+    'pytest-invenio>=1.4.0',
 ]
 
 extras_require = {
@@ -46,7 +39,6 @@ install_requires = [
     'Flask-CeleryExt>=0.3.4',
     'invenio-base>=1.2.3',
     'msgpack>=0.6.2',
-    'pytest-celery>=0.0.0a1',
     'redis>=2.10.0',
 ]
 

--- a/tests/test_invenio_celery.py
+++ b/tests/test_invenio_celery.py
@@ -8,10 +8,9 @@
 
 """Test InvenioCelery extension."""
 
-from __future__ import absolute_import, print_function
+from unittest.mock import MagicMock, patch
 
 import pytest
-from mock import MagicMock, patch
 from pkg_resources import EntryPoint
 
 from invenio_celery import InvenioCelery


### PR DESCRIPTION
**Changes**:

- Remove old test dependencies. Use centrally managed.
- Remove Mock and use the one that comes with `unittest`
- Remove `pytest-celery`. There is no test that requires it in this module. In addition, `pytest-invenio` depends on both `invenio-celery` and `pytest-celery` which might end up in weird dependency rabbit holes.

- Pytest-invenio will be tackled in its own PR, unsure of how to proceed.
Partially closes https://github.com/inveniosoftware/cookiecutter-invenio-instance/issues/258 requires fix in `pytest-invenio` to be closed.