### PR TITLE
Bump required celery version

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -18,3 +18,4 @@ Contributors
 - Sami Hiltunen
 - Sebastian Witowski
 - Tibor Simko
+- Maximilian Moser

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2015-2018 CERN.
+# Copyright (C) 2021      TU Wien.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -35,7 +36,7 @@ setup_requires = [
 ]
 
 install_requires = [
-    'celery>=4.4.0,<5.1',
+    'celery>=5.1.0,<5.2',
     'Flask-CeleryExt>=0.3.4',
     'invenio-base>=1.2.3',
     'msgpack>=0.6.2',


### PR DESCRIPTION
Celery 4.x had its [end of life in August 2021](https://docs.celeryproject.org/en/stable/whatsnew-5.1.html#long-term-support-policy), which means that the dependency should probably be upgraded even though 5.x wants to [move fast and break things](https://docs.celeryproject.org/en/stable/whatsnew-5.1.html#preface).
Since `invenio-celery` already supported celery 5.0.x, upgrading to 5.1.x should probably not be too jarring of a move to make.
The relevant change that motivates this PR is the added support for usernames in addition to passwords for connections with Redis (which added this [ACL feature](https://redis.com/blog/getting-started-redis-6-access-control-lists-acls/) not _too_ long ago).

I have just taken `invenio-celery` for a test ride by setting up a fresh Invenio-RDM instance and keeping watch over the fixture creation, which did not show any related errors.
I'll keep an eye out for celery-related logs in `invenio-cli run` tomorrow.