### PR TITLE
remove CDeprecationWarning in context of celery 6.0.0

### DIFF
--- a/invenio_celery/config.py
+++ b/invenio_celery/config.py
@@ -2,6 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2015-2018 CERN.
+# Copyright (C) 2022 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -13,18 +14,17 @@ For further Celery configuration variables see
 documentation.
 """
 
-BROKER_URL = 'redis://localhost:6379/0'
-CELERY_BROKER_URL = BROKER_URL  # For Celery 4
+broker_url = 'redis://localhost:6379/0'
 """Broker settings."""
 
-CELERY_RESULT_BACKEND = 'redis://localhost:6379/1'
+result_backend = 'redis://localhost:6379/1'
 """The backend used to store task results."""
 
-CELERY_ACCEPT_CONTENT = ['json', 'msgpack', 'yaml']
+accept_content = ['json', 'msgpack', 'yaml']
 """A whitelist of content-types/serializers."""
 
-CELERY_RESULT_SERIALIZER = 'msgpack'
+result_serializer = 'msgpack'
 """Result serialization format. Default is ``msgpack``."""
 
-CELERY_TASK_SERIALIZER = 'msgpack'
+task_serializer = 'msgpack'
 """The default serialization method to use. Default is ``msgpack``."""

--- a/invenio_celery/ext.py
+++ b/invenio_celery/ext.py
@@ -2,6 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2015-2018 CERN.
+# Copyright (C) 2022 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -71,8 +72,16 @@ class InvenioCelery(object):
 
     def init_config(self, app):
         """Initialize configuration."""
+        config_variables = [
+            'broker_url',
+            'result_backend',
+            'accept_content',
+            'result_serializer',
+            'task_serializer',
+        ]
+
         for k in dir(config):
-            if k.startswith('CELERY_') or k.startswith('BROKER_'):
+            if k in config_variables:
                 app.config.setdefault(k, getattr(config, k))
 
     def get_queues(self):


### PR DESCRIPTION
### Description
This pull request removes the CDeprecationWarning of Celery that configuration variables will be changed with version 6.0.0 of celery.

CELERY_BROKER_URL -> removed
BROKER_URL -> broker_url
CELERY_ACCEPT_CONTENT -> accept_content
CELERY_RESULT_SERIALIZER -> result_serializer
CELERY_TASK_SERIALIZER -> task_serializer

This change made it necessary to modify the part where the configuration variables are added to the global configuration because it is no longer possible to search over variables starting with 'CELERY_'.

This change must also be made in invenio_app_rdm/config.py


