### PR TITLE
docs: Typo in the example

### DIFF
--- a/invenio_celery/__init__.py
+++ b/invenio_celery/__init__.py
@@ -50,7 +50,7 @@ is as simple as:
 
 .. code-block:: python
 
-    from mymoudle.tasks import sum
+    from mymodule.tasks import sum
     result = sum.delay(2, 2)
 
 Periodic tasks


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Typo in the class that propagates to the documentation
