### PR TITLE
fix: pkg_resources DeprecationWarning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2015-2024 CERN.
-# Copyright (C) 2022-2024 Graz University of Technology.
+# Copyright (C) 2022-2025 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -29,7 +29,7 @@ zip_safe = False
 install_requires =
     celery>=5.1.0,<5.5
     Flask-CeleryExt>=0.3.4
-    invenio-base>=2.0.0,<3.0.0
+    invenio-base>=2.3.0,<3.0.0
     msgpack>=0.6.2
     redis>=2.10.0
 


### PR DESCRIPTION
* UserWarning: pkg_resources is deprecated as an API. See
  https://setuptools.pypa.io/en/latest/pkg_resources.html. The
  pkg_resources package is slated for removal as early as 2025-11-30.
  Refrain from using this package or pin to Setuptools<81.

* in invenio-base provides a wrapper for importlib.metadata.entry_points
  to still support python3.9 until end of life
